### PR TITLE
Fix post-task review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
       - name: Run reversi-engine tests
         run: cargo test -p reversi-engine
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@
 godot/.godot/
 godot/.nomedia
 *.translation
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,16 @@ Keep the main context window clean by delegating to subagents.
 - One task per subagent for focused execution
 - Clear, specific instructions with expected output format
 - Set scope boundaries -- subagents must not modify files without explicit instruction
+
+## Build & Lint Commands
+
+- **Test**: `cargo test -p reversi-engine`
+- **Build (GDExtension)**: `cargo build -p reversi-godot`
+- **Lint**: `cargo clippy --workspace -- -D warnings`
+
+## Tech Stack
+
+- **Game engine**: Godot 4.5 (GDScript)
+- **Core engine**: Rust (reversi-engine crate, pure logic)
+- **GDExtension bridge**: Rust (reversi-godot crate, gdext v0.4.5)
+- **Cargo workspace**: root Cargo.toml with members `rust/reversi-engine` and `rust/reversi-godot`

--- a/docs/specs/reversi-engine.md
+++ b/docs/specs/reversi-engine.md
@@ -227,5 +227,5 @@ game.set_board_from_string(s: String) -> bool
 
 # History
 game.get_move_count() -> int
-game.get_move_history() -> String          # comma-separated "rc" format
+game.get_move_history() -> String          # Othello notation (e.g., "F5D6C3PS")
 ```

--- a/rust/reversi-engine/src/game.rs
+++ b/rust/reversi-engine/src/game.rs
@@ -243,6 +243,14 @@ mod tests {
     }
 
     #[test]
+    fn test_pass_rejected_when_has_moves() {
+        let mut game = Game::new();
+        // Black has legal moves at game start, so pass should be rejected
+        let result = game.pass_turn();
+        assert_eq!(result, Err(MoveError::NoFlips));
+    }
+
+    #[test]
     fn test_pass_when_no_moves() {
         // Create a board where one player has no moves
         let mut board = Board::empty();

--- a/rust/reversi-engine/src/moves.rs
+++ b/rust/reversi-engine/src/moves.rs
@@ -51,7 +51,7 @@ pub fn flipped_pieces(board: &Board, color: Color, pos: Position) -> u64 {
         let mut c = pos.col as i8 + dc;
 
         // Walk in this direction, collecting opponent pieces
-        while r >= 0 && r < 8 && c >= 0 && c < 8 {
+        while (0..8).contains(&r) && (0..8).contains(&c) {
             let bit = 1u64 << (r as u8 * 8 + c as u8);
             if opp & bit != 0 {
                 line |= bit;

--- a/rust/reversi-godot/src/bridge.rs
+++ b/rust/reversi-godot/src/bridge.rs
@@ -26,7 +26,7 @@ impl ReversiGame {
     /// Returns the cell state: 0=empty, 1=black, 2=white.
     #[func]
     fn get_cell(&self, row: i32, col: i32) -> i32 {
-        if row < 0 || row >= 8 || col < 0 || col >= 8 {
+        if !(0..8).contains(&row) || !(0..8).contains(&col) {
             return 0;
         }
         match self.game.board().get(Position::new(row as u8, col as u8)) {
@@ -97,7 +97,7 @@ impl ReversiGame {
     /// Makes a move. Returns the status (0/1/2) or -1 on error.
     #[func]
     fn play(&mut self, row: i32, col: i32) -> i32 {
-        if row < 0 || row >= 8 || col < 0 || col >= 8 {
+        if !(0..8).contains(&row) || !(0..8).contains(&col) {
             return -1;
         }
         match self.game.play(Position::new(row as u8, col as u8)) {
@@ -147,7 +147,7 @@ impl ReversiGame {
         self.game.move_history().len() as i32
     }
 
-    /// Returns the move history as a comma-separated string.
+    /// Returns the move history in standard Othello notation.
     #[func]
     fn get_move_history(&self) -> GString {
         GString::from(&self.game.move_history_string())


### PR DESCRIPTION
## Summary

Addresses all findings from the Phase 1 post-task review: clippy violations, stale spec comments, missing test coverage, incomplete .gitignore, and missing developer context in CLAUDE.md/AGENTS.md.

## Changes

- **Clippy fixes**: Replace manual range checks (`x >= 0 && x < 8`) with `(0..8).contains(&x)` in `moves.rs` and `bridge.rs`
- **CI**: Add `cargo clippy --workspace -- -D warnings` step before tests
- **Spec parity**: Fix stale `get_move_history()` comment from old "comma-separated rc format" to current "Othello notation"
- **Test coverage**: Add `test_pass_rejected_when_has_moves` — verifies `pass_turn()` returns error when player has legal moves
- **`.gitignore`**: Add IDE (`.vscode/`, `.idea/`, `*.swp`) and OS (`.DS_Store`, `Thumbs.db`) patterns
- **Developer docs**: Add Build & Lint Commands and Tech Stack sections to both `CLAUDE.md` and `AGENTS.md`

## Test plan

- [x] `cargo test -p reversi-engine` — 27 tests pass (including new test)
- [x] `cargo clippy --workspace -- -D warnings` — clean, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)