### PR TITLE
chore: roll out pinact for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Run clippy
         run: cargo clippy --workspace -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This project follows the AI-Centered Development workflow.
    - Never reuse an existing feature branch; always create a fresh one.
    - Run all lint and test checks (non-AI tooling) before creating a PR. Fix failures before proceeding.
    - Create PRs via `gh pr create` and wait for review approval before merging.
+   - When editing GitHub Actions workflows or composite actions, use `pinact` to pin or update `uses:` references rather than hand-editing version tags.
 
 3. **Context Management**:
    - Your "memory" is the `docs/` directory.

--- a/docs/issues/pinact-cannot-pin-rust-toolchain-stable.md
+++ b/docs/issues/pinact-cannot-pin-rust-toolchain-stable.md
@@ -1,0 +1,22 @@
+# pinact cannot pin `dtolnay/rust-toolchain@stable`
+
+## Summary
+
+During the `pinact` rollout, `pinact run .github/workflows/ci.yml` failed on this step:
+
+```text
+.github/workflows/ci.yml:15
+- uses: dtolnay/rust-toolchain@stable
+```
+
+`pinact` still pinned the surrounding `actions/checkout` and `Swatinem/rust-cache` references, but it could not rewrite the floating `@stable` ref.
+
+## Impact
+
+- The repository now follows the `pinact` operator path for supported action references.
+- `dtolnay/rust-toolchain@stable` remains mutable and outside the current rollout's automatic pinning.
+
+## Follow-up
+
+- Confirm whether `dtolnay/rust-toolchain` has a supported immutable release/tag strategy that `pinact` can manage.
+- If not, decide whether this workflow should keep `@stable`, switch to a different supported ref policy, or adopt an explicit exception mechanism.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -2,3 +2,5 @@
 
 Place detailed specifications here.
 Start with `system-overview.md` or similar high-level docs.
+
+- `github-actions-pinning.md`: GitHub Actions の `uses:` 参照を `pinact` で管理する運用契約

--- a/docs/specs/github-actions-pinning.md
+++ b/docs/specs/github-actions-pinning.md
@@ -1,0 +1,10 @@
+# GitHub Actions Pinning
+
+GitHub Actions workflow files and composite actions in this repository must manage `uses:` references through `pinact`.
+
+## Operator Contract
+
+- When editing `.github/workflows/*.yml` or `.github/actions/**`, use `pinact` to pin new `uses:` references and to update existing pinned references.
+- Do not hand-edit floating version tags such as `@v4`, `@stable`, or `@v2` when the change is intended to pin or refresh an action dependency; run `pinact` instead and review the resulting diff.
+- It is acceptable to scope a rollout by passing explicit file paths to `pinact run` when only part of the repository should be updated.
+- `.pinact.yaml` is optional and should be added only when explicit file arguments are insufficient to avoid out-of-scope workflow files.


### PR DESCRIPTION
## Plan / Issues

- **Plan**: N/A
- **Issues**: `docs/issues/pinact-cannot-pin-rust-toolchain-stable.md` remains open

## Type of Change

- [ ] Project Plan update
- [ ] Execution Plan (new/updated plan)
- [ ] Feature implementation
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation only
- [x] Chore (CI, tooling, deps)

## Human Instructions / Intent

Human instruction: `docs/exec-plan/todo/pinact-rollout.md $execute-task 実行`
### Additional Context from Instructing Human

- This repository is part of the workspace-wide `pinact` rollout.

## Verification

- [x] Tests pass (command: `cargo test -p reversi-engine` and `cargo test -p reversi-ai`)
- [ ] Lint passes (command: `cargo clippy --workspace -- -D warnings` timed out during local verification)
- [x] Manual verification (reviewed `pinact` diff for `.github/workflows/ci.yml`)

## Checklist

- [x] Branch created from latest `origin/main`
- [x] `docs/specs/` updated (Spec-Code Parity) — _if code changed_
- [ ] Plan moved from `todo` to `done` — _if executing a plan_
- [x] Resolved linked local issues from the plan's `Addresses:` line were moved to `docs/issues/done/`, or this PR explains why they remain open
- [x] Workflow-linter warnings reviewed; all `fixable` warnings were resolved or explicitly justified in this PR
- [x] New issues logged in `docs/issues/` — _if discovered during work_
- [ ] No unresolved blockers remain

## Dependencies

N/A

## Reviewer Notes

- `pinact` could not rewrite `dtolnay/rust-toolchain@stable`; the branch keeps the supported pinning changes and records the follow-up in `docs/issues/pinact-cannot-pin-rust-toolchain-stable.md`.

## Links

N/A

## Breaking Changes

N/A
